### PR TITLE
remove support for custom-fields on post type, not necessary

### DIFF
--- a/load-staffer.php
+++ b/load-staffer.php
@@ -243,7 +243,6 @@ function create_staff_cpt_staffer() {
 			'title',
 			'editor',
 			'revisions',
-			'custom-fields',
 			'thumbnail',
 			'excerpt'
 			)


### PR DESCRIPTION
As far as I know, you don't need the 'custom-fields' metabox to support the metabox you built for the fields. As long as there's no reason to include custom-fields, it just feels like clutter to me and might as well be removed.
