### PR TITLE
ability to filter with_front arg

### DIFF
--- a/load-staffer.php
+++ b/load-staffer.php
@@ -209,7 +209,7 @@ function create_staff_cpt_staffer() {
 	}
 	$rewrite = array(
 	'slug'                => $stafferslug,
-	'with_front'          => true,
+	'with_front'          => (bool) apply_filters( 'staffer_with_front', true ),
 	'pages'               => true,
 	'feeds'               => true,
 	);


### PR DESCRIPTION
This introduces a `staffer_with_front` filter to change the staff post type's `rewrite['with_front']` arg. This is one possible way to resolve #4. With the filter, this is all that's needed to change the permalink structure:

`add_filter( 'staffer_with_front', '__return_false' );`

That's much better than the bulkier alternative given in #4.

That said, I wonder if a new option (defaulted to `true`) would make more sense. If you've never had complaints about this issue before, then a filter is probably sufficient, otherwise, an option is probably better and this pull request should be rejected.

Like I said at first, I think `'with_front' => false` is probably a more sensible default but changing it at this point would probably break sites.
