### PR TITLE
add screen reader text to icons and appropriately escape fields

### DIFF
--- a/single-staff.php
+++ b/single-staff.php
@@ -80,35 +80,33 @@
 	<?php
 	// social + contact links
 	if ( get_post_meta ($post->ID,'staffer_staff_fb', true) != '' ) { ?>
-		<a href="<?php echo get_post_meta ($post->ID,'staffer_staff_fb', true); ?>" target="_blank">
-			<i class="fa fa-facebook fa-fw"></i></a>
+		<a href="<?php echo esc_url( get_post_meta ($post->ID,'staffer_staff_fb', true) ); ?>" target="_blank">
+			<i class="fa fa-facebook fa-fw"></i><span class="screen-reader-text">Facebook profile for <?php the_title(); ?></span></a>
 	<?php 
 		}
 	if ( get_post_meta ($post->ID,'staffer_staff_gplus', true) != '' ) { ?>
-		<a href="<?php echo get_post_meta ($post->ID,'staffer_staff_gplus', true); ?>" target="_blank">
-			<i class="fa fa-google-plus fa-fw"></i></a>
+		<a href="<?php echo esc_url( get_post_meta ($post->ID,'staffer_staff_gplus', true) ); ?>" target="_blank">
+			<i class="fa fa-google-plus fa-fw"></i><span class="screen-reader-text">Google+ for <?php the_title(); ?></span></a>
 	<?php }
 	if ( get_post_meta ($post->ID,'staffer_staff_twitter', true) != '' ) { ?>
-		<a href="<?php echo get_post_meta ($post->ID,'staffer_staff_twitter', true); ?>" target="_blank">
-			<i class="fa fa-twitter fa-fw"></i></a>
+		<a href="<?php echo esc_url( get_post_meta ($post->ID,'staffer_staff_twitter', true) ); ?>" target="_blank">
+			<i class="fa fa-twitter fa-fw"></i><span class="screen-reader-text">Twitter account for <?php the_title(); ?></span></a>
 	<?php }
 	if ( get_post_meta ($post->ID,'staffer_staff_linkedin', true) != '' ) { ?>
-		<a href="<?php echo get_post_meta ($post->ID,'staffer_staff_linkedin', true); ?>" target="_blank">
-			<i class="fa fa-linkedin fa-fw"></i></a>
+		<a href="<?php echo esc_url( get_post_meta ($post->ID,'staffer_staff_linkedin', true) ); ?>" target="_blank">
+			<i class="fa fa-linkedin fa-fw"></i><span class="screen-reader-text">LinkedIn profile for <?php the_title(); ?></span></a>
 	<?php }
 	if ( get_post_meta ($post->ID,'staffer_staff_email', true) != '' ) {
 		$email = get_post_meta ($post->ID,'staffer_staff_email', true); ?>
-		<a href="mailto:<?php echo antispambot($email);?>?Subject=<?php _e ('Contact from ', 'staffer'); ?><?php bloginfo('name'); ?>" target="_blank">
-			<i class="fa fa-envelope fa-fw"></i></a>
+		<a href="mailto:<?php echo antispambot( $email );?>?Subject=<?php _e ('Contact from ', 'staffer'); ?><?php bloginfo('name'); ?>" target="_blank">
+			<i class="fa fa-envelope fa-fw"></i><span class="screen-reader-text"><?php echo antispambot($email); ?></span></a>
 	<?php }
-	if ( get_post_meta ($post->ID,'staffer_staff_website', true) != '' ) {
-		$website = get_post_meta ($post->ID,'staffer_staff_website', true); ?>
-		<a href="<?php echo get_post_meta ($post->ID,'staffer_staff_website', true); ?>" target="_blank">
-			<i class="fa fa-user fa-fw"></i></a>
+	if ( get_post_meta ($post->ID,'staffer_staff_website', true) != '' ) { ?>
+		<a href="<?php echo esc_url( get_post_meta ($post->ID,'staffer_staff_website', true) ); ?>" target="_blank">
+			<i class="fa fa-user fa-fw"></i><span class="screen-reader-text">Website for <?php the_title(); ?></span></a>
 	<?php }
-	if ( get_post_meta ($post->ID,'staffer_staff_phone', true) != '' ) {
-		$phone = get_post_meta ($post->ID,'staffer_staff_phone', true); ?>
-			<span><?php echo get_post_meta ($post->ID,'staffer_staff_phone', true); ?></span>
+	if ( get_post_meta ($post->ID,'staffer_staff_phone', true) != '' ) { ?>
+			<span><span class="screen-reader-text">Phone for <?php the_title(); ?>: </span><?php echo esc_html( get_post_meta ($post->ID,'staffer_staff_phone', true) ); ?></span>
 	<?php }
 	?>
 	</div>


### PR DESCRIPTION
Fixes #3. Additionally escapes all profile icon values for better security and removes to errant variables that weren't being used (`$website` and `$email`).

Depending on your philosophy, this PR may be incomplete.

It relies on the presence of a `.screen-reader-text` class which is [recently required](https://make.wordpress.org/themes/2015/01/26/supporting-screen-reader-text/) for [all WordPress themes](https://make.wordpress.org/accessibility/tag/screen-reader/). It's in all the newest versions of the core themes, but certainly not all themes provide it. Luckily, if it's not there, it's not the end of the world since the text labels are clear and make sense. That said, some people may complain.

If this were my plugin, I would _not_ include the `.screen-reader-text` class in the plugin and for those that have problems, encourage them to install the ["'.screen-reader-text' theme support" plugin](https://wordpress.org/plugins/screen-reader-text-theme-support/)  for full support. It's important for accessibility not just in this plugin so a bit of education won't hurt anyone :)

Let me know if you'd like me to either add the CSS class for in-plugin support or whether we can just update the readme to mention the screen reader text plugin.
